### PR TITLE
FIX: QVC/BS-TBS channel confliction issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ libs/
 *.pvr
 *.dll
 *.zip
+/VS2015/.vs/pvr.chinachu/v14/.suo
+/VS2015/chinachu/Release/chinachu.Build.CppClean.log
+/VS2015/chinachu/Release/chinachu.log
+/VS2015/pvr_client/Release/pvr.chinachu.Build.CppClean.log
+/VS2015/pvr_client/Release/pvr_client.log
+/VS2015/pvr.chinachu.VC.db
+/VS2015/pvr.chinachu.VC.VC.opendb

--- a/src/chinachu/recorded.cpp
+++ b/src/chinachu/recorded.cpp
@@ -66,7 +66,10 @@ namespace chinachu {
 			const int sid = p["channel"].get<picojson::object>()["sid"].is<std::string>() ?
 				std::atoi((p["channel"].get<picojson::object>()["sid"].get<std::string>()).c_str()) :
 				(int)(p["channel"].get<picojson::object>()["sid"].get<double>());
-			rec.iChannelUid = sid;
+			const int nid = p["channel"].get<picojson::object>()["nid"].is<std::string>() ?
+				std::atoi((p["channel"].get<picojson::object>()["nid"].get<std::string>()).c_str()) :
+				(int)(p["channel"].get<picojson::object>()["nid"].get<double>());
+			rec.iChannelUid = sid+nid*100000;
 			snprintf(rec.strStreamURL, PVR_ADDON_URL_STRING_LENGTH - 1, (const char*)(chinachu::api::baseURL + recordedStreamingPath).c_str(), p["id"].get<std::string>().c_str());
 			if (showThumbnail) {
 				snprintf(rec.strThumbnailPath, PVR_ADDON_URL_STRING_LENGTH - 1, (const char*)(chinachu::api::baseURL + recordedThumbnailPath).c_str(), p["id"].get<std::string>().c_str());

--- a/src/chinachu/recording.cpp
+++ b/src/chinachu/recording.cpp
@@ -67,7 +67,10 @@ namespace chinachu {
 			const int sid = p["channel"].get<picojson::object>()["sid"].is<std::string>() ?
 				std::atoi((p["channel"].get<picojson::object>()["sid"].get<std::string>()).c_str()) :
 				(int)(p["channel"].get<picojson::object>()["sid"].get<double>());
-			rec.iChannelUid = sid;
+			const int nid = p["channel"].get<picojson::object>()["nid"].is<std::string>() ?
+				std::atoi((p["channel"].get<picojson::object>()["nid"].get<std::string>()).c_str()) :
+				(int)(p["channel"].get<picojson::object>()["nid"].get<double>());
+			rec.iChannelUid = sid + nid * 100000;
 			snprintf(rec.strStreamURL, PVR_ADDON_URL_STRING_LENGTH - 1, (const char*)(chinachu::api::baseURL + recordingStreamingPath).c_str(), p["id"].get<std::string>().c_str());
 			if (showThumbnail) {
 				snprintf(rec.strThumbnailPath, PVR_ADDON_URL_STRING_LENGTH - 1, (const char*)(chinachu::api::baseURL + recordingThumbnailPath).c_str(), p["id"].get<std::string>().c_str());

--- a/src/chinachu/reserves.cpp
+++ b/src/chinachu/reserves.cpp
@@ -56,7 +56,13 @@ namespace chinachu {
 			resv.iClientIndex = resv.iEpgUid;
 			resv.iClientChannelUid = p["channel"].get<picojson::object>()["sid"].is<std::string>() ?
 				std::atoi((p["channel"].get<picojson::object>()["sid"].get<std::string>()).c_str()) :
-				(int)(p["channel"].get<picojson::object>()["sid"].get<double>());
+				(int)(p["channel"].get<picojson::object>()["sid"].get<double>())
+				+
+				(p["channel"].get<picojson::object>()["nid"].is<std::string>() ?
+				std::atoi((p["channel"].get<picojson::object>()["nid"].get<std::string>()).c_str()) :
+				(int)(p["channel"].get<picojson::object>()["nid"].get<double>())) * 100000;
+
+
 			strncpy(resv.strTitle, p["fullTitle"].get<std::string>().c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
 			strncpy(resv.strSummary, p["detail"].get<std::string>().c_str(), PVR_ADDON_DESC_STRING_LENGTH - 1);
 			strncpy(resv.strDirectory, p["id"].get<std::string>().c_str(), PVR_ADDON_URL_STRING_LENGTH - 1); // instead of strProgramId

--- a/src/chinachu/rules.cpp
+++ b/src/chinachu/rules.cpp
@@ -121,7 +121,7 @@ namespace chinachu {
 
 			if (p["channels"].is<picojson::array>() && p["channels"].get<picojson::array>().size() == 1) {
 				char *endptr;
-				rule.iClientChannelUid = strtoul(p["channels"].get<picojson::array>()[0].get<std::string>().c_str(), &endptr, 36) % 100000;
+				rule.iClientChannelUid = strtoul(p["channels"].get<picojson::array>()[0].get<std::string>().c_str(), &endptr, 36);
 			}
 
 			rule.bIsDisabled = (p["isDisabled"].is<bool>() && p["isDisabled"].get<bool>());

--- a/src/chinachu/schedule.cpp
+++ b/src/chinachu/schedule.cpp
@@ -52,24 +52,11 @@ namespace chinachu {
 			}
 
 			PVR_CHANNEL ch;
-			ch.iUniqueId = o["sid"].is<double>() ? (int)(o["sid"].get<double>()) : 0;
+			ch.iUniqueId = (o["sid"].is<double>() ? (int)(o["sid"].get<double>()) : 0)+(o["nid"].is<double>() ? (int)(o["nid"].get<double>()) : 0) * 100000;
 			ch.bIsRadio = false;
 			ch.bIsHidden = false;
 
-			std::string channel = o["channel"].is<std::string>() ? o["channel"].get<std::string>() : "0";
-			// Remove non-numerical charactor from channel number
-			while (channel.find_first_of("0123456789") != 0) {
-				channel.erase(channel.begin());
-				// If channel number contains only charactors,
-				if (channel.empty()) {
-					// use sid instead.
-					channel = o["sid"].is<std::string>() ?
-						std::atoi((o["sid"].get<std::string>()).c_str()) :
-						(int)(o["sid"].get<double>());
-					break;
-				}
-			}
-			ch.iChannelNumber = std::atoi(channel.c_str());
+			ch.iChannelNumber = o["n"].is<double>() ? (int)(o["n"].get<double>()) : 0;
 
 			ch.iSubChannelNumber = o["nid"].is<double>() ? (int)(o["nid"].get<double>()) : 0;
 			// use channel id as name instead when name field isn't available.

--- a/src/pvr_client/timer.cpp
+++ b/src/pvr_client/timer.cpp
@@ -236,7 +236,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer) {
 					for (const PVR_CHANNEL channel: channelGroups.second) {
 						if (channel.iUniqueId == timer.iClientChannelUid) {
 							strChannelType = channelGroups.first;
-							strChannelId = channel_id_string(channel.iSubChannelNumber, channel.iUniqueId);
+							strChannelId = channel_id_string(channel.iSubChannelNumber, channel.iUniqueId % 100000);
 							break;
 						}
 					}


### PR DESCRIPTION
「#21 表示されないチャンネルがある、等」のIssueについて、
BS-TBSとQVCでsidが重なってしまっていたので、
UniqueId= sid + nid * 100000 にして、ChannelNumber に"n"の値を使うようにして回避を試みました。
手元では正常に動いているように見えます。もし宜しければ、見て頂ければ幸いです。m(_　_)m
